### PR TITLE
Docs Update for 10MHz Reference Switch

### DIFF
--- a/docs/hardware_overview.md
+++ b/docs/hardware_overview.md
@@ -442,7 +442,7 @@ The GNSSDO has robust SMA connectors for the mosaic-T GNSS antenna, Pulse-Per-Se
 	<figcaption markdown>The SMA connector for the EventA input.</figcaption>
 	</figure>
 
-	The Event A SMA connector is standard polarity. The voltage is adjustable via the VCCIO switch: 3.3V or 5V. 2.8V and 1.8V are also available via the jumper links *(see the **[Jumpers](#jumpers)** section)*. The output 	can also be configured for 50 Ohm via the jumper links *(see the **[Jumpers](#jumpers)** section)*.
+	The Event A SMA connector is standard polarity. The voltage is adjustable via the VCCIO switch: 3.3V or 5V. 2.8V and 1.8V are also available via the jumper links *(see the **[Jumpers](#jumpers)** section)*. The output can also be configured for 50 Ohm via the jumper links *(see the **[Jumpers](#jumpers)** section)*.
 
 	</div>
 
@@ -470,7 +470,7 @@ The GNSSDO has robust SMA connectors for the mosaic-T GNSS antenna, Pulse-Per-Se
 	<figcaption markdown>The SMA connector for the 10 MHz output / input.</figcaption>
 	</figure>
 
-	The 10 MHz SMA connector is standard polarity. The voltage is adjustable via the VCCIO switch: 3.3V or 5V. 2.8V and 1.8V are also available via the jumper links *(see the **[Jumpers](#jumpers)** section)*. The output 	can also be configured for 50 Ohm via the jumper links *(see the **[Jumpers](#jumpers)** section)*. Output / Input is selected via the small slide switch *(see the **[Switches](#switches)** section)* adjacent to the connector. When configured for input: the input 	impedance is 50Ω; the detection level is -14dBm; the max supported input level is +12dBm.
+	The 10 MHz SMA connector is standard polarity. The voltage is adjustable via the VCCIO switch: 3.3V or 5V. 2.8V and 1.8V are also available via the jumper links *(see the **[Jumpers](#jumpers)** section)*. The output can also be configured for 50 Ohm via the jumper links *(see the **[Jumpers](#jumpers)** section)*. Output / Input is selected via the small slide switch *(see the **[Switches](#switches)** section)* adjacent to the connector. When configured for input: the input impedance is 50Ω; the detection level is -14dBm; the max supported input level is +12dBm.
 
 	</div>
 
@@ -502,7 +502,7 @@ The GNSSDO has robust SMA connectors for the mosaic-T GNSS antenna, Pulse-Per-Se
 	<figcaption markdown>The SMA connector for the Pulse-Per-Second output.</figcaption>
 	</figure>
 
-	The Pulse-Per-Second SMA connector is standard polarity. The voltage is selectable via the VCCIO switch: 3.3V or 5V. 2.8V and 1.8V are also available via the jumper links *(see the **[Jumpers](#jumpers)** section)*. The 	output is DC-coupled. The output can be configured for 50 Ohm output via the jumper links *(see the **[Jumpers](#jumpers)** section)*.
+	The Pulse-Per-Second SMA connector is standard polarity. The voltage is selectable via the VCCIO switch: 3.3V or 5V. 2.8V and 1.8V are also available via the jumper links *(see the **[Jumpers](#jumpers)** section)*. The output is DC-coupled. The output can be configured for 50 Ohm output via the jumper links *(see the **[Jumpers](#jumpers)** section)*.
 
 	</div>
 

--- a/docs/hardware_overview.md
+++ b/docs/hardware_overview.md
@@ -470,7 +470,7 @@ The GNSSDO has robust SMA connectors for the mosaic-T GNSS antenna, Pulse-Per-Se
 	<figcaption markdown>The SMA connector for the 10 MHz output / input.</figcaption>
 	</figure>
 
-	The 10 MHz SMA connector is standard polarity. The voltage is adjustable via the VCCIO switch: 3.3V or 5V. 2.8V and 1.8V are also available via the jumper links *(see the **[Jumpers](#jumpers)** section)*. The output 	can also be configured for 50 Ohm via the jumper links *(see the **[Jumpers](#jumpers)** section)*. Output / Input is selected via the small slide switch adjacent to the connector. When configured for input: the input 	impedance is 50Ω; the detection level is -14dBm; the max supported input level is +12dBm.
+	The 10 MHz SMA connector is standard polarity. The voltage is adjustable via the VCCIO switch: 3.3V or 5V. 2.8V and 1.8V are also available via the jumper links *(see the **[Jumpers](#jumpers)** section)*. The output 	can also be configured for 50 Ohm via the jumper links *(see the **[Jumpers](#jumpers)** section)*. Output / Input is selected via the small slide switch *(see the **[Switches](#switches)** section)* adjacent to the connector. When configured for input: the input 	impedance is 50Ω; the detection level is -14dBm; the max supported input level is +12dBm.
 
 	</div>
 
@@ -485,6 +485,10 @@ The GNSSDO has robust SMA connectors for the mosaic-T GNSS antenna, Pulse-Per-Se
 	</div>
 
 	</div>
+
+
+	!!! warning
+		Although the mosaic-T module can either use its internal TCXO or accept an external signal as a frequency reference, the module will constantly reboot if the `REF_I` pin isn't provided a 10MHz sinusoidal signal and left floating. Therefore, users should only set the [`10MHz` switch](#switches) to the `IN` position, only if a 10MHz clock signal can be provided; otherwise, the switch should remain in the `OUT` position.
 
 
 === "`PPS`"
@@ -724,6 +728,12 @@ There are two miniature slide switches on the GNSSDO PCB:
 </figure>
 
 
+!!! warning
+	The mosaic-T module can either use its internal TCXO or accept an external signal as a frequency reference. However, the module will constantly reboot if the `REF_I` pin isn't provided a 10MHz sinusoidal signal and left floating. Therefore, users should only set the `10MHz` switch to the `IN` position, only if a 10MHz clock signal can be provided; otherwise, the switch should remain in the `OUT` position.
+
+	Additionally, switching between an external and internal frequency reference must occur when the mosaic-T is powered off, or the module must be reset after switching states.
+
+
 === "`VCCIO`"
 	This switch sets the voltage of the Input Output Terminals (COM2 UART, Event B, SCL2 & SDA2)
 
@@ -736,7 +746,7 @@ There are two miniature slide switches on the GNSSDO PCB:
 		- The SMA connector will output a 10MHz "CMOS" disciplined clock signal
 		- The signal voltage is set by the VCCIO voltage selection switch
 	- When set to `IN`:
-		- The user can apply a clock signal from an external 10MHz oscillator
+		- The user **must apply a clock signal from an external 10MHz oscillator**; otherwise, the mosaic-T module will constantly reset
 		- The input impedance is 50Ω
 		- The detection level is -14dBm
 		- The max supported input level is +12dBm

--- a/docs/troubleshooting_tips.md
+++ b/docs/troubleshooting_tips.md
@@ -73,6 +73,7 @@ You can update or reload the firmware using the [SparkFun RTK Firmware Uploader]
 
 The full firmware source code is available in our [GitHub repository](https://github.com/sparkfun/SparkFun_GNSSDO/tree/main/Firmware/GNSSDO_Firmware)
 
+
 ## Enclosure Disassembly
 Due to the ESD sensitivity of the mosaic-T module, we don't recommend disassembling the GNSSDO. However, if users must access the PCB to troubleshoot an issue, make a modification, or repair a component, we highly recommend that they take the necessary ESD precautions to avoid damaging the mosaic-T module.
 
@@ -131,6 +132,14 @@ Once the terminal blocks have been removed, users can remove the front and rear 
 	We recommend removing the front panel first to prevent the Qwiic cable from being yanked off the OLED display or main PCB. Once the front panel is free, carefully lift the panel and disconnect the Qwiic cable from the top connector on the OLED display.
 
 At this point, if users have previously disconnected all the cables and the terminal blocks from the back, the GNSSDO PCB should slide out of the enclosure. Users can then, remove the rear panel from the enclosure to complete the teardown process.
+
+
+## Clock Frequency Reference
+The mosaic-T module can either use its internal TCXO or accept an external signal as a frequency reference. However, the module will constantly reboot if the `REF_I` pin isn't provided a 10MHz sinusoidal signal and left floating. Therefore, users should only set the `10MHz` switch to the `IN` position, only if a 10MHz clock signal can be provided; otherwise, the switch should remain in the `OUT` position.
+
+!!! note
+	Switching between an external and internal frequency reference must occur when the mosaic-T is powered off, or the module must be reset after switching.
+
 
 <!-- QR Code for Hookup Guide (Displayed when printed) -->
 <center>


### PR DESCRIPTION
Updated information and instructions for the 10MHz clock frequency reference switch.

- SMA Connector
    - Added a call out box for the 10MHz SMA connector
        ![image](https://github.com/user-attachments/assets/dcf193a8-6dfd-43a5-82eb-8fa7b12f83d0)
- Switches
    - Added a call out box for the section
        ![image](https://github.com/user-attachments/assets/5bec7d40-9086-4ff6-9f70-4c05121b9e14)
    - Updated the instructions to **must apply**
            ![image](https://github.com/user-attachments/assets/82111cb8-e5e3-4996-a26d-a2f06536021b)
- Troubleshooting Tips
    - Added information
        ![image](https://github.com/user-attachments/assets/4a83d921-e5d7-41db-a053-b74cbc5e1e2c)